### PR TITLE
fix recipe asking user input and add Dockerfile

### DIFF
--- a/symfony.sh
+++ b/symfony.sh
@@ -3,7 +3,7 @@
 # ======================
 
 # This page contains a list of terminal commands that
-# create a Django web application with routing, templates
+# create a Symfony web application with routing, templates
 # and user accounts.
 #
 # You can start from a fresh debian installation. Or with a

--- a/symfony.sh
+++ b/symfony.sh
@@ -34,11 +34,10 @@ composer create-project symfony/website-skeleton mysite --no-interaction
 chown -R www-data:www-data mysite
 cd mysite
 
+# Ensure composer doesn't ask us questions about recipes and allow contrib recipes
+composer config extra.symfony --json '{"allow-contrib": true}'
 # apache-pack will write the public/.htaccess file that
 # routes all requests to public/index.php.
-# Unfortunately, this will ask a question and you will
-# have to manually type "y" and enter. I have not yet
-# found a nice way to automate this.
 composer require symfony/apache-pack
 
 # ====================


### PR DESCRIPTION
Fixed issue with composer require symfony/apache-pack asking for user input
by ensuring beforehand that allow-contrib is set to true. Additionally,
added a Dockerfile for ease of development.

Would've liked to make a larger addition to the symfony script, but I ran out of available time today, figured these changes could still be helpful. 

If you don't like the idea of a Dockerfile, I'll happily omit it from the PR ofcourse :)